### PR TITLE
Added support for getting the mode and also battery_level from device

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,12 +41,13 @@ Usage
     # listing base stations
     arlo.base_stations
 
+    # get base station handle
+    # assuming only 1 base station is available
+    base = arlo.base_stations[0]
+
     # listing Arlo modes
     base.available_modes
     ['armed', 'disarmed', 'schedule', 'custom']
-
-    # setting a mode
-    garage_cam.mode = 'armed'
 
     # listing all cameras
     arlo.cameras
@@ -54,10 +55,35 @@ Usage
     # showing camera preferences
     cam = arlo.cameras[0]
 
+    # setting a mode
+    cam.mode = 'armed'
+
+    # getting the current active mode
+    cam.mode
+    'armed'
+
     # printing camera attributes
     cam.serial_number
     cam.model_id
     cam.unseen_videos
+
+    # get current battery level of camera
+    cam.get_battery_level
+    92
+
+    # get battery levels of all cameras
+    # prints serial number and battery level of each camera
+    base.get_camera_battery_level
+    {'4N71235T12345': 92, '4N71235T12345': 90}    
+
+    # get base station properties
+    base.get_basestation_properties
+
+    # get camera properties
+    base.get_camera_properties
+
+    # get camera rules
+    base.get_camera_rules
 
     # refreshing camera properties
     cam.update()

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,10 @@ Usage
     # showing camera preferences
     cam = arlo.cameras[0]
 
+    # check if camera is connected to base station
+    cam.is_camera_connected
+    True
+
     # setting a mode
     cam.mode = 'armed'
 
@@ -67,9 +71,29 @@ Usage
     cam.model_id
     cam.unseen_videos
 
+    # get brightness value of camera
+    cam.get_brightness
+
+    # get signal strength of camera with base station
+    cam.get_signal_strength
+    
+    # get flip property from camera
+    cam.get_flip_state
+
+    # get mirror property from camera
+    cam.get_mirror_state
+
+    # get power save mode value from camera
+    cam.get_powersave_mode
+
     # get current battery level of camera
     cam.get_battery_level
     92
+
+    # get boolean result if motion detection
+    # is enabled or not
+    cam.is_motion_detection_enabled
+    True
 
     # get battery levels of all cameras
     # prints serial number and battery level of each camera
@@ -84,6 +108,12 @@ Usage
 
     # get camera rules
     base.get_camera_rules
+
+    # get camera schedule
+    base.get_camera_schedule
+
+    # get camera motion detection sensitivity
+    cam.get_motion_detection_sensitivity
 
     # refreshing camera properties
     cam.update()

--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -8,11 +8,8 @@ from pyarlo.camera import ArloCamera
 from pyarlo.media import ArloMediaLibrary
 from pyarlo.const import (
     BILLING_ENDPOINT, DEVICES_ENDPOINT,
-    FRIENDS_ENDPOINT,LOGIN_ENDPOINT, PROFILE_ENDPOINT,
+    FRIENDS_ENDPOINT, LOGIN_ENDPOINT, PROFILE_ENDPOINT,
     PRELOAD_DAYS, RESET_ENDPOINT)
-import sseclient
-import json
-import threading
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -227,7 +227,7 @@ class PyArlo(object):
 
     @property
     def is_connected(self):
-        """Return connection status."""
+        """Connection status of client with Arlo system."""
         return bool(self.authenticated)
 
     def update(self):

--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -40,6 +40,7 @@ class PyArlo(object):
         self.__password = password
         self.__username = username
         self.session = requests.Session()
+        self.__base_stations = []
 
         # login user
         self.login()
@@ -180,10 +181,10 @@ class PyArlo(object):
 
             if device.get('deviceType') == 'basestation' and \
                device.get('state') == 'provisioned':
-                devices['base_station'].append(ArloBaseStation(name,
-                                                               device,
-                                                               self.__token,
-                                                               self))
+                base = ArloBaseStation(name, device, self.__token, self)
+                devices['base_station'].append(base)
+                self.__base_stations.append(base)
+
         return devices
 
     def lookup_camera_by_id(self, device_id):

--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -7,9 +7,12 @@ from pyarlo.base_station import ArloBaseStation
 from pyarlo.camera import ArloCamera
 from pyarlo.media import ArloMediaLibrary
 from pyarlo.const import (
-    BILLING_ENDPOINT, DEVICES_ENDPOINT, FRIENDS_ENDPOINT,
-    LOGIN_ENDPOINT, PROFILE_ENDPOINT, PRELOAD_DAYS,
-    RESET_ENDPOINT)
+    BILLING_ENDPOINT, DEVICES_ENDPOINT,
+    FRIENDS_ENDPOINT,LOGIN_ENDPOINT, PROFILE_ENDPOINT,
+    PRELOAD_DAYS, RESET_ENDPOINT)
+import sseclient
+import json
+import threading
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +93,8 @@ class PyArlo(object):
               extra_params=None,
               extra_headers=None,
               retry=3,
-              raw=False):
+              raw=False,
+              stream=False):
         """
         Return a JSON object or raw session.
 
@@ -129,7 +133,7 @@ class PyArlo(object):
 
             # define connection method
             if method == 'GET':
-                req = self.session.get(url, headers=headers)
+                req = self.session.get(url, headers=headers, stream=stream)
             elif method == 'PUT':
                 req = self.session.put(url, json=params, headers=headers)
             elif method == 'POST':
@@ -145,6 +149,7 @@ class PyArlo(object):
 
                 # leave if everything worked fine
                 break
+
         return response
 
     @property
@@ -179,6 +184,7 @@ class PyArlo(object):
                device.get('state') == 'provisioned':
                 devices['base_station'].append(ArloBaseStation(name,
                                                                device,
+                                                               self.__token,
                                                                self))
         return devices
 

--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -101,6 +101,7 @@ class PyArlo(object):
         :param extra_headers: Dictionary to be apppended on request.headers
         :param retry: Attempts to retry a query. Default is 3.
         :param raw: Boolean if query() will return request object instead JSON.
+        :param stream: Boolean if query() will return a stream object.
         """
         response = None
         loop = 0

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -1,7 +1,13 @@
 # coding: utf-8
 """Generic Python Class file for Netgear Arlo Base Station module."""
 import logging
-from pyarlo.const import ACTION_MODES, NOTIFY_ENDPOINT, RUN_ACTION_BODY
+from pyarlo.const import ACTION_MODES, NOTIFY_ENDPOINT
+from pyarlo.const import (
+    ACTION_BODY, SUBSCRIBE_ENDPOINT, UNSUBSCRIBE_ENDPOINT)
+import sseclient
+import json
+import threading
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -9,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 class ArloBaseStation(object):
     """Arlo Base Station module implementation."""
 
-    def __init__(self, name, attrs, arlo_session):
+    def __init__(self, name, attrs, session_token, arlo_session):
         """Initialize Arlo Base Station object.
 
         :param name: Base Station name
@@ -19,10 +25,133 @@ class ArloBaseStation(object):
         self.name = name
         self._attrs = attrs
         self._session = arlo_session
+        self._session_token = session_token
+        self.__sseclient = None
+        self.__subscribed = False
+        self.__events = []
 
     def __repr__(self):
         """Representation string of object."""
         return "<{0}: {1}>".format(self.__class__.__name__, self.name)
+
+    def thread_function(arg):
+        """Thread function."""
+        self = arg
+        url = SUBSCRIBE_ENDPOINT + "?token=" + self._session_token
+        data = self._session.query(url, method='GET', raw=True, stream=True)
+        self._sseclient = sseclient.SSEClient(data)
+        if self._sseclient:
+            self.__subscribed = True
+        for event in (self._sseclient).events():
+            if self.__subscribed == False:
+                break
+            data = json.loads(event.data)
+            if 'status' in data:
+                if data['status'] == "connected":
+                    _LOGGER.debug("Successfully subscribed this base station for notifications")
+            elif 'action' in data:
+                action = data['action']
+                if action == "logout":
+                    _LOGGER.debug("Logged out from the Arlo system by some other entity")
+                    self.__subscribed = False
+                    break
+                elif action == "is":
+                    self.__events.append(data)
+
+    def _get_event_stream(self):
+        """Spawn a thread and monitor the Arlo Event Stream."""
+        event_thread = threading.Thread(target = self.thread_function)
+        event_thread.start()
+
+    def _subscribe_myself(self):
+        """Subscribe this base station for all events."""
+        return self.__run_action(method='SET', resource='subscribe', mode=None, publish_response=False)
+
+    def _unsubscribe_myself(self):
+        """Unsubscribe this base station for all events."""
+        url = UNSUBSCRIBE_ENDPOINT
+        return self._session.query(url, method='GET', raw=True, stream=False)
+
+    def _close_event_stream(self):
+        """Stop the Event stream thread."""
+        self.__subscribed = False
+
+    def publish_and_get_event(self, resource):
+        """Publish and get the event from base station."""
+        self._get_event_stream()
+        self._subscribe_myself()
+
+        this_event = ''
+        status = self.__run_action(method='GET', resource=resource, mode=None, publish_response=False)
+        if status == 'success':
+            for i in range(0, 5):
+                for event in self.__events:
+                    if event['resource'] == resource:
+                        this_event = event
+                        self.__events.remove(event)
+                        break
+                if this_event:
+                    break
+                else:
+                    time.sleep(0.5)
+
+        self._unsubscribe_myself()
+        self._close_event_stream()
+
+        if this_event:
+            return this_event
+
+        return None
+
+    def __run_action(self,
+                    method = 'GET',
+                    resource = None,
+                    mode = None,
+                    publish_response = None):
+        """Run action."""
+        url = NOTIFY_ENDPOINT.format(self.device_id)
+
+        body = ACTION_BODY
+
+        if resource:
+            body['resource'] = resource
+
+        if method == 'GET':
+            body['action'] = "get"
+            body['properties'] = None
+        elif method == 'SET':
+            body['action'] = "set"
+            if resource == 'schedule':
+                body['properties'] = {'active': 'true'}
+            elif resource == 'subscribe':
+                body['resource'] = "subscriptions/" + "{0}_web".format(self.user_id)
+                dev = []
+                dev.append(self.device_id)
+                body['properties'] = {'devices': dev}
+            elif resource == 'modes':
+                body['properties'] = {'active': ACTION_MODES.get(mode)}
+        else:
+            _LOGGER.info("Invalid method requested")
+            return None
+
+        if not publish_response:
+            body['publishResponse'] = 'false'
+        else:
+            body['publishResponse'] = 'true'
+
+        body['from'] = "{0}_web".format(self.user_id)
+        body['to'] = self.device_id
+        body['transId'] = "web!e6d1b969.8aa4b!1498165992111"
+
+        _LOGGER.info("Action body: %s", body)
+
+        ret = \
+            self._session.query(url, method='POST', extra_params=body,
+                                extra_headers={"xCloudId": self.xcloud_id})
+        if ret.get('success'):
+            return 'success'
+
+        return None
 
     # pylint: disable=invalid-name
     @property
@@ -75,35 +204,85 @@ class ArloBaseStation(object):
         """Return X-Cloud-ID attribute."""
         return self._attrs.get('xCloudId')
 
-    def __run_action(self, action):
-        """Run action."""
-        url = NOTIFY_ENDPOINT.format(self.device_id)
-        body = RUN_ACTION_BODY
-        body['from'] = "{0}_web".format(self.user_id)
-        body['to'] = self.device_id
-        body['properties'] = {'active': ACTION_MODES.get(action)}
-
-        # if action is schedule, modify resource and properties
-        if action == 'schedule':
-            body['resource'] = 'schedule'
-            body['properties'] = {'active': 'true'}
-
-        _LOGGER.debug("Action body: %s", body)
-
-        ret = \
-            self._session.query(url, method='POST', extra_params=body,
-                                extra_headers={"xCloudId": self.xcloud_id})
-        return ret.get('success')
-
     @property
     def available_modes(self):
         """Return list of available modes."""
         return list(ACTION_MODES.keys())
 
     @property
+    def available_resources(self):
+        """Return list of available resources."""
+        return list(RESOURCES.keys())
+
+    @property
     def mode(self):
         """Return current mode."""
+        resource = "modes"
+        mode_event = self.publish_and_get_event(resource)
+        if mode_event:
+            active_mode = mode_event['properties']['active']
+            modes = mode_event['properties']['modes']
+            for mode in modes:
+                if mode['id'] == active_mode:
+                    return mode['type']
+
         return None
+
+    @property
+    def get_camera_properties(self):
+        """Return camera properties."""
+        resource = "cameras"
+        resource_event = self.publish_and_get_event(resource)
+        if resource_event:
+            return (resource_event['properties'])
+
+        return None
+
+    @property
+    def get_camera_battery_level(self):
+        """Return cameras battery level."""
+        battery_levels = {}
+        resource = "cameras"
+        resource_event = self.publish_and_get_event(resource)
+        if resource_event:
+            cameras = resource_event['properties']
+            for camera in cameras:
+                battery_levels[camera['serialNumber']] = camera['batteryLevel']
+            return battery_levels
+
+        return None
+
+    @property
+    def get_basestation_properties(self):
+        """Return the base station info."""
+        resource = "basestation"
+        basestn_event = self.publish_and_get_event(resource)
+        if basestn_event:
+            return (basestn_event['properties'])
+
+        return None
+
+    @property
+    def get_camera_rules(self):
+        """Return the camera rules."""
+        resource = "rules"
+        rules_event = self.publish_and_get_event(resource)
+        if rules_event:
+            return (rules_event['properties'])
+
+        return None
+
+    @property
+    def subscribe(self):
+        """Subscribe this session with Arlo system."""
+        self._get_event_stream()
+        self._subscribe_myself()
+
+    @property
+    def unsubscribe(self):
+        """Unsubscribe this session."""
+        self._unsubscribe_myself()
+        self._close_event_stream()
 
     @mode.setter
     def mode(self, mode):
@@ -113,7 +292,7 @@ class ArloBaseStation(object):
         """
         if mode not in ACTION_MODES.keys():
             return "Invalid mode"
-        return self.__run_action(mode)
+        return self.__run_action(method='SET', resource='modes', mode=mode, publish_response=True)
 
     def update(self):
         """Update object properties."""

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -46,7 +46,7 @@ class ArloBaseStation(object):
                 break
             data = json.loads(event.data)
             if data.get('status') == "connected":
-                    _LOGGER.debug("Successfully subscribed this base station")
+                _LOGGER.debug("Successfully subscribed this base station")
             elif data.get('action'):
                 action = data['action']
                 if action == "logout":
@@ -256,7 +256,6 @@ class ArloBaseStation(object):
     @property
     def get_camera_battery_level(self):
         """Return a list of battery levels of all cameras."""
-        """Return cameras battery level."""
         battery_levels = {}
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -131,6 +131,84 @@ class ArloCamera(object):
         base = self._session.base_stations[0]
         return base.get_camera_battery_level[self.device_id]
 
+    @property
+    def get_signal_strength(self):
+        """Get the camera Signal strength."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['signalStrength']
+
+        return None
+
+    @property
+    def get_brightness(self):
+        """Get the brightness property of camera."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['brightness']
+
+        return None
+
+    @property
+    def get_mirror_state(self):
+        """Get the brightness property of camera."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['flip']
+
+        return None
+
+    @property
+    def get_flip_state(self):
+        """Get the brightness property of camera."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['mirror']
+
+        return None
+
+    @property
+    def get_powersave_mode(self):
+        """Get the brightness property of camera."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['powerSaveMode']
+
+        return None
+
+    @property
+    def is_camera_connected(self):
+        """Connectivity status of Cam with Base Station."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return bool(cam['connectionState'] == 'available')
+
+        return None
+
     def live_streaming(self):
         """Return live streaming generator."""
         url = STREAM_ENDPOINT

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -129,7 +129,7 @@ class ArloCamera(object):
     def get_battery_level(self):
         """Get the camera battery level."""
         base = self._session.base_stations[0]
-        return (base.get_camera_battery_level[self.device_id])
+        return base.get_camera_battery_level[self.device_id]
 
     def live_streaming(self):
         """Return live streaming generator."""

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -209,6 +209,19 @@ class ArloCamera(object):
 
         return None
 
+    @property
+    def get_motion_detection_sensitivity(self):
+        """Sensitivity level of Camera motion detection."""
+        base = self._session.base_stations[0]
+        props = base.get_camera_properties
+        if not props:
+            return None
+        for cam in props:
+            if cam['serialNumber'] == self.device_id:
+                return cam['capabilities'][9]['Triggers'][0]['sensitivity']['default']
+
+        return None
+
     def live_streaming(self):
         """Return live streaming generator."""
         url = STREAM_ENDPOINT

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -218,9 +218,9 @@ class ArloCamera(object):
             return None
         for cam in props:
             if cam['serialNumber'] == self.device_id:
-                return cam['capabilities'][9]['Triggers'][0]['sensitivity']['default']
-
-        return None
+                this_cam = cam
+        triggers = this_cam['capabilities'][9]['Triggers']
+        return triggers[0]['sensitivity']['default']
 
     def live_streaming(self):
         """Return live streaming generator."""

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -125,6 +125,12 @@ class ArloCamera(object):
         """Return X-Cloud-ID attribute."""
         return self._attrs.get('xCloudId')
 
+    @property
+    def get_battery_level(self):
+        """Get the camera battery level."""
+        base = self._session.base_stations[0]
+        return (base.get_camera_battery_level[self.device_id])
+
     def live_streaming(self):
         """Return live streaming generator."""
         url = STREAM_ENDPOINT

--- a/pyarlo/const.py
+++ b/pyarlo/const.py
@@ -3,11 +3,14 @@
 # API Endpoints
 API_URL = "https://arlo.netgear.com/hmsweb"
 
-BILLING_ENDPOINT = API_URL + "/users/serviceLevel"
+DEVICE_SUPPORT_ENDPOINT = API_URL + "/devicesupport/v2"
+SUBSCRIBE_ENDPOINT = API_URL + "/client/subscribe"
+UNSUBSCRIBE_ENDPOINT = API_URL + "/client/unsubscribe"
+BILLING_ENDPOINT = API_URL + "/users/serviceLevel/v2"
 DEVICES_ENDPOINT = API_URL + "/users/devices"
 FRIENDS_ENDPOINT = API_URL + "/users/friends"
 LIBRARY_ENDPOINT = API_URL + "/users/library"
-LOGIN_ENDPOINT = API_URL + "/login"
+LOGIN_ENDPOINT = API_URL + "/login/v2"
 LOGOUT_ENDPOINT = API_URL + "/logout"
 NOTIFY_ENDPOINT = API_URL + "/users/devices/notify/{0}"
 PROFILE_ENDPOINT = API_URL + "/users/profile"
@@ -26,13 +29,22 @@ ACTION_MODES = {
     'schedule': 'true',
 }
 
+# define resources
+RESOURCES = {
+    'base_station': 'base_station',
+    'modes': 'modes',
+    'schedule': 'schedule',
+    'rules': 'rules',
+    'cameras': 'cameras',
+}
+
 # define body used when executing an action
-RUN_ACTION_BODY = {
-    'action': 'set',
+ACTION_BODY = {
+    'action': None,
     'from': None,
     'properties': None,
-    'publishResponse': 'true',
-    'resource': 'modes',
+    'publishResponse': None,
+    'resource': None,
     'to': None
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+sseclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-sseclient
+sseclient-py

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/tchellomello/python-arlo',
     license='LGPLv3+',
     include_package_data=True,
-    install_requires=['requests'],
+    install_requires=['requests', 'sseclient-py'],
     test_suite='tests',
     keywords=[
         'arlo',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, lint
+envlist = py27, py34, py35, py36, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Currrent code didn't have the capability to read the mode from the arlo base station/device.  Added support to do the same.  Also added property code to get the battery level of all the cameras (as we are talking to base station), and similarly added properties to print out the camera properties, base station properties, schedule, rules etc.

Tested the code in my home arlo system and it works.  Once this is approved and signed-off, we can update the Home Assistant code (which uses this pyarlo library) to fetch the status from the device directly.

This will help in keeping sync between app, website and Hass.

We basically needed to subscribe ourself (python app using this library is the client) with the base station, and then subscribe for notifications. Then when client requests for modes or schedules or rules etc, we would get the notification via the event stream.  We need to parse that and return the data.

Fixes: https://github.com/tchellomello/python-arlo/issues/20 https://github.com/tchellomello/python-arlo/issues/5