### PR TITLE
Fix basestation mode property for custom mode settings.

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -239,9 +239,7 @@ class ArloBaseStation(object):
             modes = mode_event['properties']['modes']
             for mode in modes:
                 if mode['id'] == active_mode:
-                    if 'type' in mode:
-                        return mode['type']
-                    return mode.get('name', None)
+                    return mode.get('type') if mode.get('type') is not None else mode.get('name')
         return None
 
     @property

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -239,7 +239,8 @@ class ArloBaseStation(object):
             modes = mode_event['properties']['modes']
             for mode in modes:
                 if mode['id'] == active_mode:
-                    return mode.get('type') if mode.get('type') is not None else mode.get('name')
+                    return mode.get('type') \
+                        if mode.get('type') is not None else mode.get('name')
         return None
 
     @property

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -241,8 +241,7 @@ class ArloBaseStation(object):
                 if mode['id'] == active_mode:
                     if 'type' in mode:
                         return mode['type']
-                    else:
-                        return mode.get('name', None)
+                    return mode.get('name', None)
         return None
 
     @property

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -239,8 +239,10 @@ class ArloBaseStation(object):
             modes = mode_event['properties']['modes']
             for mode in modes:
                 if mode['id'] == active_mode:
-                    return mode['type']
-
+                    if 'type' in mode:
+                        return mode['type']
+                    else:
+                        return mode.get('name', None)
         return None
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='pyarlo',
     packages=['pyarlo'],
-    version='0.0.6',
+    version='0.0.7',
     description='Python Arlo is a library written in Python 2.7/3x ' +
                 'that exposes the Netgear Arlo cameras as Python objects.',
     author='Marcelo Moreira de Mello',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='pyarlo',
     packages=['pyarlo'],
-    version='0.0.7',
+    version='0.0.6',
     description='Python Arlo is a library written in Python 2.7/3x ' +
                 'that exposes the Netgear Arlo cameras as Python objects.',
     author='Marcelo Moreira de Mello',


### PR DESCRIPTION
Fixed issue where custom mode settings caused an exception to occur when retrieving mode from a basestation.
Bump version.

Fixes: https://github.com/tchellomello/python-arlo/issues/27