### PR TITLE
Optimization: Instead of subscribing for each query, user can subscribe once and then post query

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -164,7 +164,7 @@ class ArloBaseStation(object):
         body['to'] = self.device_id
         body['transId'] = "web!e6d1b969.8aa4b!1498165992111"
 
-        _LOGGER.info("Action body: %s", body)
+        _LOGGER.debug("Action body: %s", body)
 
         ret = \
             self._session.query(url, method='POST', extra_params=body,

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -81,8 +81,12 @@ class ArloBaseStation(object):
 
     def publish_and_get_event(self, resource):
         """Publish and get the event from base station."""
-        self._get_event_stream()
-        self._subscribe_myself()
+        l_subscribe = 0
+
+        if not self.__subscribed:
+            self._get_event_stream()
+            self._subscribe_myself()
+            l_subscribe = 1
 
         this_event = ''
         status = self.__run_action(
@@ -102,8 +106,10 @@ class ArloBaseStation(object):
                 if this_event:
                     break
 
-        self._unsubscribe_myself()
-        self._close_event_stream()
+        if l_subscribe == 1:
+            l_subscribe = 0
+            self._unsubscribe_myself()
+            self._close_event_stream()
 
         if this_event:
             return this_event


### PR DESCRIPTION
Whenever user requests for getting the mode, battery level etc, we would internally subscribe to the base station.  This would spawn a thread and wait for events. Then the client will ask the query to which the thread will receive the event response. Then the thread will be stopped and subscription unsubscribed.

This optimization would allow clients to subscribe once after login. This will spawn the thread and subscribe for events.  Then user can just ask the query which will be responded by base station.  This will help even for HASS where we can call subscribe once after login, and then do remaining operations.