### PR TITLE
Arlo Optimizations & New property to get camera signal strength

### DIFF
--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -153,12 +153,12 @@ class PyArlo(object):
     @property
     def cameras(self):
         """Return all cameras linked on Arlo account."""
-        return self.devices['cameras']
+        return self.devices.get('cameras')
 
     @property
     def base_stations(self):
         """Return all base stations linked on Arlo account."""
-        return self.devices['base_station']
+        return self.devices.get('base_station')
 
     @property
     def devices(self):

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -270,8 +270,8 @@ class ArloBaseStation(object):
         if resource_event:
             cameras = resource_event['properties']
             for camera in cameras:
-                serialnum = camera['serialNumber']
-                cam_battery = camera['batteryLevel']
+                serialnum = camera.get('serialNumber')
+                cam_battery = camera.get('batteryLevel')
                 battery_levels[serialnum] = cam_battery
             return battery_levels
 
@@ -286,8 +286,8 @@ class ArloBaseStation(object):
         if resource_event:
             cameras = resource_event['properties']
             for camera in cameras:
-                serialnum = camera['serialNumber']
-                cam_strength = camera['signalStrength']
+                serialnum = camera.get('serialNumber')
+                cam_strength = camera.get('signalStrength')
                 signal_strength[serialnum] = cam_strength
             return signal_strength
 

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -246,6 +246,9 @@ class ArloBaseStation(object):
             properties = mode_event.get('properties')
             active_mode = properties.get('active')
             modes = properties.get('modes')
+            if not modes:
+                return None
+
             for mode in modes:
                 if mode.get('id') == active_mode:
                     return mode.get('type') \

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -243,10 +243,11 @@ class ArloBaseStation(object):
         resource = "modes"
         mode_event = self.publish_and_get_event(resource)
         if mode_event:
-            active_mode = mode_event['properties']['active']
-            modes = mode_event['properties']['modes']
+            properties = mode_event.get('properties')
+            active_mode = properties.get('active')
+            modes = properties.get('modes')
             for mode in modes:
-                if mode['id'] == active_mode:
+                if mode.get('id') == active_mode:
                     return mode.get('type') \
                         if mode.get('type') is not None else mode.get('name')
         return None
@@ -257,7 +258,7 @@ class ArloBaseStation(object):
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)
         if resource_event:
-            return resource_event['properties']
+            return resource_event.get('properties')
 
         return None
 
@@ -268,7 +269,7 @@ class ArloBaseStation(object):
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)
         if resource_event:
-            cameras = resource_event['properties']
+            cameras = resource_event.get('properties')
             for camera in cameras:
                 serialnum = camera.get('serialNumber')
                 cam_battery = camera.get('batteryLevel')
@@ -284,7 +285,7 @@ class ArloBaseStation(object):
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)
         if resource_event:
-            cameras = resource_event['properties']
+            cameras = resource_event.get('properties')
             for camera in cameras:
                 serialnum = camera.get('serialNumber')
                 cam_strength = camera.get('signalStrength')
@@ -299,7 +300,7 @@ class ArloBaseStation(object):
         resource = "basestation"
         basestn_event = self.publish_and_get_event(resource)
         if basestn_event:
-            return basestn_event['properties']
+            return basestn_event.get('properties')
 
         return None
 
@@ -309,7 +310,7 @@ class ArloBaseStation(object):
         resource = "rules"
         rules_event = self.publish_and_get_event(resource)
         if rules_event:
-            return rules_event['properties']
+            return rules_event.get('properties')
 
         return None
 
@@ -319,7 +320,7 @@ class ArloBaseStation(object):
         resource = "schedule"
         schedule_event = self.publish_and_get_event(resource)
         if schedule_event:
-            return schedule_event['properties']
+            return schedule_event.get('properties')
 
         return None
 


### PR DESCRIPTION
Optimizations for improving the speed/time of subscribing and waiting for event. Earlier it used to be 5 seconds for each subscribe and getting event. This new model allows client applications using this library to just subscribe first, and then just keep querying for information. Client application can unsubscribe when done.

This saves time in getting the info needed to barely 0.7 seconds. Removed the while loop to wait for an event, and using the threading event concept. Also added a new property to get the signal strength as a dictionary.

We are using this concept in Home Assistant and this helped in fetching the status/properties of arlo camera in HASS.