### PR TITLE
Base Station Mode enhancements

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,6 +69,10 @@ Ready to contribute? Here's how to set up `python-arlo` for local development.
 
     $ tox -r
 
+    During development, you can also quickly run unit tests with::
+
+    $ pytest
+
 6. Commit your changes and push your branch to GitHub::
 
     $ git add .

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,14 @@ Usage
     # assuming only 1 base station is available
     base = arlo.base_stations[0]
 
+    # get the current base station mode
+    base.mode  # 'disarmed'
+
     # listing Arlo modes
-    base.available_modes
-    ['armed', 'disarmed', 'schedule', 'custom']
+    base.available_modes # ['armed', 'disarmed', 'schedule', 'custom']
+
+    # Updating the base station mode
+    base.mode = 'custom'
 
     # listing all cameras
     arlo.cameras
@@ -59,15 +64,7 @@ Usage
     cam = arlo.cameras[0]
 
     # check if camera is connected to base station
-    cam.is_camera_connected
-    True
-
-    # setting a mode
-    cam.mode = 'armed'
-
-    # getting the current active mode
-    cam.mode
-    'armed'
+    cam.is_camera_connected  # True
 
     # printing camera attributes
     cam.serial_number
@@ -95,13 +92,11 @@ Usage
 
     # get boolean result if motion detection
     # is enabled or not
-    cam.is_motion_detection_enabled
-    True
+    cam.is_motion_detection_enabled  # True
 
     # get battery levels of all cameras
     # prints serial number and battery level of each camera
-    base.get_camera_battery_level
-    {'4N71235T12345': 92, '4N71235T12345': 90}    
+    base.get_camera_battery_level  # {'4N71235T12345': 92, '4N71235T12345': 90}
 
     # get base station properties
     base.get_basestation_properties
@@ -122,8 +117,7 @@ Usage
     cam.update()
 
     # gathering live_streaming URL
-    cam.live_streaming()
-    rtmps://vzwow72-z2-prod.vz.netgear.com:80/vzmodulelive?egressToken=b723a7bb_abbXX&userAgent=web&cameraId=48AAAAA
+    cam.live_streaming()  # rtmps://vzwow72-z2-prod.vz.netgear.com:80/vzmodulelive?egressToken=b723a7bb_abbXX&userAgent=web&cameraId=48AAAAA
 
     # gather last recorded video URL
     cam.last_video.video_url

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -240,7 +240,9 @@ class ArloBaseStation(object):
     def available_modes_with_ids(self):
         """Return list of objects containing available mode name and id."""
         modes = self.get_available_modes()
-        simple_modes = dict([(m.get("type", m.get("name")), m.get("id")) for m in modes])
+        simple_modes = dict(
+            [(m.get("type", m.get("name")), m.get("id")) for m in modes]
+        )
         all_modes = FIXED_MODES.copy()
         all_modes.update(simple_modes)
         return all_modes

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -6,7 +6,7 @@ import logging
 import sseclient
 from pyarlo.const import (
     ACTION_BODY, SUBSCRIBE_ENDPOINT, UNSUBSCRIBE_ENDPOINT,
-    ACTION_MODES, NOTIFY_ENDPOINT, RESOURCES)
+    FIXED_MODES, NOTIFY_ENDPOINT, RESOURCES)
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -134,7 +134,7 @@ class ArloBaseStation(object):
         """
         url = NOTIFY_ENDPOINT.format(self.device_id)
 
-        body = ACTION_BODY
+        body = ACTION_BODY.copy()
 
         if resource:
             body['resource'] = resource
@@ -153,7 +153,9 @@ class ArloBaseStation(object):
                 dev.append(self.device_id)
                 body['properties'] = {'devices': dev}
             elif resource == 'modes':
-                body['properties'] = {'active': ACTION_MODES.get(mode)}
+                available_modes = self.available_modes_with_ids
+                body['properties'] = {'active': available_modes.get(mode)}
+
         else:
             _LOGGER.info("Invalid method requested")
             return None
@@ -172,6 +174,7 @@ class ArloBaseStation(object):
         ret = \
             self._session.query(url, method='POST', extra_params=body,
                                 extra_headers={"xCloudId": self.xcloud_id})
+
         if ret.get('success'):
             return 'success'
 
@@ -230,8 +233,17 @@ class ArloBaseStation(object):
 
     @property
     def available_modes(self):
-        """Return list of available modes."""
-        return list(ACTION_MODES.keys())
+        """Return list of available mode names."""
+        return list(self.available_modes_with_ids.keys())
+
+    @property
+    def available_modes_with_ids(self):
+        """Return list of objects containing available mode name and id."""
+        modes = self.get_available_modes()
+        simple_modes = dict([(m.get("type", m.get("name")), m.get("id")) for m in modes])
+        all_modes = FIXED_MODES.copy()
+        all_modes.update(simple_modes)
+        return all_modes
 
     @property
     def available_resources(self):
@@ -240,7 +252,7 @@ class ArloBaseStation(object):
 
     @property
     def mode(self):
-        """Return current mode."""
+        """Return current mode key."""
         resource = "modes"
         mode_event = self.publish_and_get_event(resource)
         if mode_event:
@@ -254,6 +266,16 @@ class ArloBaseStation(object):
                 if mode.get('id') == active_mode:
                     return mode.get('type') \
                         if mode.get('type') is not None else mode.get('name')
+        return None
+
+    def get_available_modes(self):
+        """Return a list of available mode objects for an Arlo user."""
+        resource = "modes"
+        resource_event = self.publish_and_get_event(resource)
+        if resource_event:
+            properties = resource_event.get("properties")
+            return properties.get("modes")
+
         return None
 
     @property
@@ -351,8 +373,8 @@ class ArloBaseStation(object):
 
         :param mode: arm, disarm
         """
-        if mode not in ACTION_MODES.keys():
-            return "Invalid mode"
+        if mode not in self.available_modes:
+            return
         self.__run_action(
             method='SET',
             resource='modes',

--- a/pyarlo/const.py
+++ b/pyarlo/const.py
@@ -21,12 +21,9 @@ STREAM_ENDPOINT = API_URL + "/users/devices/startStream"
 # number of days to preload video
 PRELOAD_DAYS = 30
 
-# define action modes
-ACTION_MODES = {
-    'armed': 'mode1',
-    'disarmed': 'mode0',
-    'custom': 'mode2',
-    'schedule': 'true',
+# modes not returned with the Arlo API's available modes
+FIXED_MODES = {
+    'schedule': 'true'
 }
 
 # define resources

--- a/tests/fixtures/pyarlo_modes.json
+++ b/tests/fixtures/pyarlo_modes.json
@@ -1,0 +1,16 @@
+{
+	"resource": "modes",
+	"to": "FQ8QKG-336-14182007_web",
+	"action": "is",
+	"from": "4R03757BA387F",
+	"transId": "web!e6d1b969.8aa4b!1498165992111",
+	"properties": {
+		"active": "mode0",
+		"modes": [
+			{"id": "mode0", "type": "disarmed", "name": "", "rules": []},
+			{"id": "mode1", "type": "armed", "name": "", "rules": ["rule0", "rule1", "rule2", "rule3"]},
+			{"id": "mode3", "name": "Inside", "rules": ["rule5", "rule6", "rule7"]},
+			{"id": "mode4", "name": "Home", "rules": ["rule15", "rule16", "rule17"]}
+		]
+	}
+}

--- a/tests/fixtures/pyarlo_success.json
+++ b/tests/fixtures/pyarlo_success.json
@@ -1,0 +1,1 @@
+{"success": false}

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,37 @@
+"""The tests for the PyArlo platform."""
+import unittest
+from mock import patch
+from pyarlo import ArloBaseStation, PyArlo
+from tests.common import load_fixture
+
+import json
+import requests_mock
+
+from pyarlo.const import (
+    DEVICES_ENDPOINT, LIBRARY_ENDPOINT, LOGIN_ENDPOINT)
+
+USERNAME = "foo"
+PASSWORD = "bar"
+USERID = "999-123456"
+
+
+class TestArloBaseStationModes(unittest.TestCase):
+    """Tests for ArloBaseStation component modes."""
+
+    def load_modes(self, _):
+        return json.loads(load_fixture("pyarlo_modes.json"))
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    def test_current_mode(self, mock):
+        """Test PyArlo BaseStation.mode property."""
+        mock.post(LOGIN_ENDPOINT,
+                  text=load_fixture("pyarlo_authentication.json"))
+        mock.get(DEVICES_ENDPOINT, text=load_fixture("pyarlo_devices.json"))
+        mock.post(LIBRARY_ENDPOINT, text=load_fixture("pyarlo_videos.json"))
+
+        arlo = PyArlo(USERNAME, PASSWORD, days=1)
+        base_station = arlo.base_stations[0]
+        print base_station.mode
+
+        self.assertEqual(base_station.mode, "disarmed")

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -36,7 +36,6 @@ class TestArloBaseStationModes(unittest.TestCase):
         base_station = self.load_base_station(mock)
         self.assertEqual(base_station.mode, "disarmed")
 
-
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
     def test_get_available_modes(self, mock):
@@ -46,17 +45,21 @@ class TestArloBaseStationModes(unittest.TestCase):
         mocked_modes = self.load_modes()
         self.assertEqual(available_modes, mocked_modes["properties"]["modes"])
 
-
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
     def test_available_modes_with_ids(self, mock):
         """Test PyArlo BaseStation.available_modes_with_ids property."""
         base_station = self.load_base_station(mock)
         available_modes = base_station.available_modes_with_ids
-        mocked_modes = self.load_modes()
         self.assertEqual(
             available_modes,
-            {"schedule": "true", "disarmed": "mode0", "armed": "mode1", "Inside": "mode3", "Home": "mode4"}
+            {
+                "schedule": "true",
+                "disarmed": "mode0",
+                "armed": "mode1",
+                "Inside": "mode3",
+                "Home": "mode4"
+            }
         )
 
     @requests_mock.Mocker()
@@ -65,10 +68,9 @@ class TestArloBaseStationModes(unittest.TestCase):
         """Test PyArlo BaseStation.available_modes property."""
         base_station = self.load_base_station(mock)
         available_modes = base_station.available_modes
-        mocked_modes = self.load_modes()
         self.assertEqual(
-            available_modes,
-            ["Home", "Inside", "armed", "disarmed", "schedule"]
+            set(available_modes),
+            set(["Home", "Inside", "armed", "disarmed", "schedule"])
         )
 
     @requests_mock.Mocker()
@@ -83,9 +85,12 @@ class TestArloBaseStationModes(unittest.TestCase):
         base_station.mode = "Inside"
         request_number = mock.call_count - 2
         request = mock.request_history[request_number]
-        self.assertEqual("{}://{}{}".format(request.scheme, request.netloc, request.path), notify_url)
-        body = request.json()
+        self.assertEqual(
+            "{}://{}{}".format(request.scheme, request.netloc, request.path),
+            notify_url
+        )
 
+        body = request.json()
         self.assertEqual(body.get("publishResponse"), "true")
         self.assertEqual(body.get("action"), "set")
         self.assertEqual(body.get("resource"), "modes")

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -8,7 +8,7 @@ import json
 import requests_mock
 
 from pyarlo.const import (
-    DEVICES_ENDPOINT, LIBRARY_ENDPOINT, LOGIN_ENDPOINT)
+    DEVICES_ENDPOINT, LIBRARY_ENDPOINT, LOGIN_ENDPOINT, NOTIFY_ENDPOINT)
 
 USERNAME = "foo"
 PASSWORD = "bar"
@@ -18,20 +18,75 @@ USERID = "999-123456"
 class TestArloBaseStationModes(unittest.TestCase):
     """Tests for ArloBaseStation component modes."""
 
-    def load_modes(self, _):
+    def load_modes(self, *args, **kwargs):
         return json.loads(load_fixture("pyarlo_modes.json"))
+
+    def load_base_station(self, mock):
+        mock.post(LOGIN_ENDPOINT,
+                  text=load_fixture("pyarlo_authentication.json"))
+        mock.get(DEVICES_ENDPOINT, text=load_fixture("pyarlo_devices.json"))
+        mock.post(LIBRARY_ENDPOINT, text=load_fixture("pyarlo_videos.json"))
+        arlo = PyArlo(USERNAME, PASSWORD, days=1)
+        return arlo.base_stations[0]
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
     def test_current_mode(self, mock):
         """Test PyArlo BaseStation.mode property."""
-        mock.post(LOGIN_ENDPOINT,
-                  text=load_fixture("pyarlo_authentication.json"))
-        mock.get(DEVICES_ENDPOINT, text=load_fixture("pyarlo_devices.json"))
-        mock.post(LIBRARY_ENDPOINT, text=load_fixture("pyarlo_videos.json"))
-
-        arlo = PyArlo(USERNAME, PASSWORD, days=1)
-        base_station = arlo.base_stations[0]
-        print base_station.mode
-
+        base_station = self.load_base_station(mock)
         self.assertEqual(base_station.mode, "disarmed")
+
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    def test_get_available_modes(self, mock):
+        """Test PyArlo BaseStation.get_available_modes method."""
+        base_station = self.load_base_station(mock)
+        available_modes = base_station.get_available_modes()
+        mocked_modes = self.load_modes()
+        self.assertEqual(available_modes, mocked_modes["properties"]["modes"])
+
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    def test_available_modes_with_ids(self, mock):
+        """Test PyArlo BaseStation.available_modes_with_ids property."""
+        base_station = self.load_base_station(mock)
+        available_modes = base_station.available_modes_with_ids
+        mocked_modes = self.load_modes()
+        self.assertEqual(
+            available_modes,
+            {"schedule": "true", "disarmed": "mode0", "armed": "mode1", "Inside": "mode3", "Home": "mode4"}
+        )
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    def test_available_modes(self, mock):
+        """Test PyArlo BaseStation.available_modes property."""
+        base_station = self.load_base_station(mock)
+        available_modes = base_station.available_modes
+        mocked_modes = self.load_modes()
+        self.assertEqual(
+            available_modes,
+            ["Home", "Inside", "armed", "disarmed", "schedule"]
+        )
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    def test_set_mode(self, mock):
+        """Test PyArlo BaseStation.mode property."""
+        notify_url = NOTIFY_ENDPOINT.format("48b14cbbbbbbb")
+
+        mock.post(notify_url, text=load_fixture("pyarlo_success.json"))
+        base_station = self.load_base_station(mock)
+
+        base_station.mode = "Inside"
+        request_number = mock.call_count - 2
+        request = mock.request_history[request_number]
+        self.assertEqual("{}://{}{}".format(request.scheme, request.netloc, request.path), notify_url)
+        body = request.json()
+
+        self.assertEqual(body.get("publishResponse"), "true")
+        self.assertEqual(body.get("action"), "set")
+        self.assertEqual(body.get("resource"), "modes")
+        self.assertEqual(body.get("properties"), {"active": "mode3"})


### PR DESCRIPTION
This makes a change to pull all available modes from the Arlo API and also adds the ability to set custom modes on the Arlo base station.

I tested this on my personal Arlo pro setup and was able to set both the predefined and my custom defined modes.