### PR TITLE
Refactored and enhanced camera properties calls *breaking_change**

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -308,10 +308,10 @@ class ArloBaseStation(object):
     def camera_properties(self):
         """Return _camera_properties"""
         if self._camera_properties is None:
-            self.get_camera_properties()
+            self.get_cameras_properties()
         return self._camera_properties
 
-    def get_camera_properties(self):
+    def get_cameras_properties(self):
         """Return camera properties."""
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)
@@ -320,8 +320,7 @@ class ArloBaseStation(object):
             self._camera_properties = resource_event.get('properties')
         return
 
-    @property
-    def get_camera_battery_level(self):
+    def get_cameras_battery_level(self):
         """Return a list of battery levels of all cameras."""
         battery_levels = {}
         if not self.camera_properties:
@@ -333,8 +332,7 @@ class ArloBaseStation(object):
             battery_levels[serialnum] = cam_battery
         return battery_levels
 
-    @property
-    def get_camera_signal_strength(self):
+    def get_cameras_signal_strength(self):
         """Return a list of signal strength of all cameras."""
         signal_strength = {}
         if not self.camera_properties:
@@ -347,7 +345,7 @@ class ArloBaseStation(object):
         return signal_strength
 
     @property
-    def get_basestation_properties(self):
+    def properties(self):
         """Return the base station info."""
         resource = "basestation"
         basestn_event = self.publish_and_get_event(resource)
@@ -356,8 +354,7 @@ class ArloBaseStation(object):
 
         return None
 
-    @property
-    def get_camera_rules(self):
+    def get_cameras_rules(self):
         """Return the camera rules."""
         resource = "rules"
         rules_event = self.publish_and_get_event(resource)
@@ -366,8 +363,7 @@ class ArloBaseStation(object):
 
         return None
 
-    @property
-    def get_camera_schedule(self):
+    def get_cameras_schedule(self):
         """Return the schedule set for cameras."""
         resource = "schedule"
         schedule_event = self.publish_and_get_event(resource)
@@ -428,7 +424,7 @@ class ArloBaseStation(object):
         last_refresh = 0 if self._last_refresh is None else self._last_refresh
 
         if current_time >= (last_refresh + self._refresh_rate):
-            self.get_camera_properties()
+            self.get_cameras_properties()
             self._attrs = self._session.refresh_attributes(self.name)
             _LOGGER.debug("Called base station update of camera properties: "
                           "Scan Interval: %s, New Properties: %s",

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -10,6 +10,8 @@ from pyarlo.const import (
     FIXED_MODES, NOTIFY_ENDPOINT, RESOURCES)
 _LOGGER = logging.getLogger(__name__)
 
+REFRESH_RATE = 15
+
 
 class ArloBaseStation(object):
     """Arlo Base Station module implementation."""
@@ -30,7 +32,7 @@ class ArloBaseStation(object):
         self._available_mode_ids = None
         self._camera_properties = None
         self._last_refresh = None
-        self._refresh_rate = 15
+        self._refresh_rate = REFRESH_RATE
         self.__sseclient = None
         self.__subscribed = False
         self.__events = []
@@ -244,11 +246,6 @@ class ArloBaseStation(object):
         return self._attrs.get('xCloudId')
 
     @property
-    def camera_properties(self):
-        """Return _camera_properties"""
-        return self._camera_properties
-
-    @property
     def available_modes(self):
         """Return list of available mode names."""
         if not self._available_modes:
@@ -308,26 +305,29 @@ class ArloBaseStation(object):
         return None
 
     @property
+    def camera_properties(self):
+        """Return _camera_properties"""
+        if self._camera_properties is None:
+            self.get_camera_properties()
+        return self._camera_properties
+
     def get_camera_properties(self):
         """Return camera properties."""
         resource = "cameras"
         resource_event = self.publish_and_get_event(resource)
         if resource_event:
-            self._camera_properties = resource_event.get('properties')
             self._last_refresh = int(time.time())
-            return resource_event.get('properties')
-
-        return None
+            self._camera_properties = resource_event.get('properties')
+        return
 
     @property
     def get_camera_battery_level(self):
         """Return a list of battery levels of all cameras."""
         battery_levels = {}
-        camera_properties = self.get_camera_properties
-        if not camera_properties:
+        if not self.camera_properties:
             return None
 
-        for camera in camera_properties:
+        for camera in self.camera_properties:
             serialnum = camera.get('serialNumber')
             cam_battery = camera.get('batteryLevel')
             battery_levels[serialnum] = cam_battery
@@ -337,11 +337,10 @@ class ArloBaseStation(object):
     def get_camera_signal_strength(self):
         """Return a list of signal strength of all cameras."""
         signal_strength = {}
-        camera_properties = self.get_camera_properties
-        if not camera_properties:
+        if not self.camera_properties:
             return None
 
-        for camera in camera_properties:
+        for camera in self.camera_properties:
             serialnum = camera.get('serialNumber')
             cam_strength = camera.get('signalStrength')
             signal_strength[serialnum] = cam_strength
@@ -427,11 +426,13 @@ class ArloBaseStation(object):
         """Update object properties."""
         current_time = int(time.time())
         last_refresh = 0 if self._last_refresh is None else self._last_refresh
+
         if current_time >= (last_refresh + self._refresh_rate):
-            props = self.get_camera_properties
+            self.get_camera_properties()
             self._attrs = self._session.refresh_attributes(self.name)
-            _LOGGER.debug("Called base station update on camera properties: "
+            _LOGGER.debug("Called base station update of camera properties: "
                           "Scan Interval: %s, New Properties: %s",
-                          self._refresh_rate, props)
+                          self._refresh_rate, self.camera_properties)
+        return
 
 # vim:sw=4:ts=4:et:

--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -167,37 +167,37 @@ class ArloCamera(object):
         return None
 
     @property
-    def get_battery_level(self):
+    def battery_level(self):
         """Get the camera battery level."""
         properties = self.properties
         return properties.get("batteryLevel") if properties else None
 
     @property
-    def get_signal_strength(self):
+    def signal_strength(self):
         """Get the camera Signal strength."""
         properties = self.properties
         return properties.get("signalStrength") if properties else None
 
     @property
-    def get_brightness(self):
+    def brightness(self):
         """Get the brightness property of camera."""
         properties = self.properties
         return properties.get("brightness") if properties else None
 
     @property
-    def get_mirror_state(self):
+    def mirror_state(self):
         """Get the mirror state of camera image."""
         properties = self.properties
         return properties.get("mirror") if properties else None
 
     @property
-    def get_flip_state(self):
+    def flip_state(self):
         """Get the flipped state of camera image."""
         properties = self.properties
         return properties.get("flip") if properties else None
 
     @property
-    def get_powersave_mode(self):
+    def powersave_mode(self):
         """Get the power mode (stream quality) of camera."""
         properties = self.properties
         return properties.get("powerSaveMode") if properties else None
@@ -210,7 +210,7 @@ class ArloCamera(object):
             if properties else None
 
     @property
-    def get_motion_detection_sensitivity(self):
+    def motion_detection_sensitivity(self):
         """Sensitivity level of Camera motion detection."""
         if not self.triggers:
             return None
@@ -226,7 +226,7 @@ class ArloCamera(object):
         return None
 
     @property
-    def get_audio_detection_sensitivity(self):
+    def audio_detection_sensitivity(self):
         """Sensitivity level of Camera audio detection."""
         if not self.triggers:
             return None

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -68,14 +68,14 @@ class TestArloBaseStation(unittest.TestCase):
     def test_get_properties(self, mock):
         """Test ArloBaseStation.get_basestation_properties."""
         base = self.load_base_station(mock)
-        base_properties = base.get_basestation_properties
+        base_properties = base.properties
         mocked_properties = load_base_props()
         self.assertEqual(base_properties, mocked_properties["properties"])
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_props)
     def test_camera_properties(self, mock):
-        """Test ArloBaseStation.get_camera_properties."""
+        """Test ArloBaseStation.get_cameras_properties."""
         base = self.load_base_station(mock)
         camera_properties = base.camera_properties
         mocked_properties = load_camera_props()
@@ -84,29 +84,29 @@ class TestArloBaseStation(unittest.TestCase):
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_props)
     def test_battery_level(self, mock):
-        """Test ArloBaseStation.get_camera_battery_level."""
+        """Test ArloBaseStation.get_cameras_battery_level."""
         base = self.load_base_station(mock)
         self.assertEqual(
-            base.get_camera_battery_level,
+            base.get_cameras_battery_level(),
             {"48B14C1299999": 95, "48B14CAAAAAAA": 77}
         )
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_props)
     def test_signal_strength(self, mock):
-        """Test ArloBaseStation.get_camera_signal_strength."""
+        """Test ArloBaseStation.get_cameras_signal_strength."""
         base = self.load_base_station(mock)
         self.assertEqual(
-            base.get_camera_signal_strength,
+            base.get_cameras_signal_strength(),
             {"48B14C1299999": 4, "48B14CAAAAAAA": 3}
         )
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_rules)
     def test_camera_rules(self, mock):
-        """Test ArloBaseStation.get_camera_rules."""
+        """Test ArloBaseStation.get_cameras_rules."""
         base = self.load_base_station(mock)
-        camera_rules = base.get_camera_rules
+        camera_rules = base.get_cameras_rules()
         mocked_rules = load_camera_rules()
         self.assertEqual(camera_rules, mocked_rules["properties"])
 
@@ -114,8 +114,8 @@ class TestArloBaseStation(unittest.TestCase):
     @patch.object(
         ArloBaseStation, "publish_and_get_event", load_camera_schedule)
     def test_camera_schedule(self, mock):
-        """Test ArloBaseStation.get_camera_schedule."""
+        """Test ArloBaseStation.get_cameras_schedule."""
         base = self.load_base_station(mock)
-        camera_schedule = base.get_camera_schedule
+        camera_schedule = base.get_cameras_schedule()
         mocked_schedules = load_camera_schedule()
         self.assertEqual(camera_schedule, mocked_schedules["properties"])

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -77,7 +77,7 @@ class TestArloBaseStation(unittest.TestCase):
     def test_camera_properties(self, mock):
         """Test ArloBaseStation.get_camera_properties."""
         base = self.load_base_station(mock)
-        camera_properties = base.get_camera_properties
+        camera_properties = base.camera_properties
         mocked_properties = load_camera_props()
         self.assertEqual(camera_properties, mocked_properties["properties"])
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -60,7 +60,6 @@ class TestArloCamera(unittest.TestCase):
             self.assertEqual(camera.timezone, "America/New_York")
             self.assertEqual(camera.user_role, "ADMIN")
             self.assertTrue(len(camera.captured_today), 1)
-            self.assertIsNotNone(camera._extended_properties)
             self.assertIsNotNone(camera.properties)
 
             if camera.name == "Front Door":

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -69,14 +69,14 @@ class TestArloCamera(unittest.TestCase):
                 self.assertEqual(camera.xcloud_id, "1005-123-999999")
                 self.assertEqual(camera.serial_number, camera.device_id)
 
-                self.assertEqual(camera.get_battery_level, 77)
-                self.assertEqual(camera.get_signal_strength, 3)
-                self.assertEqual(camera.get_brightness, 0)
-                self.assertEqual(camera.get_mirror_state, 0)
-                self.assertEqual(camera.get_flip_state, 0)
-                self.assertEqual(camera.get_powersave_mode, 2)
+                self.assertEqual(camera.battery_level, 77)
+                self.assertEqual(camera.signal_strength, 3)
+                self.assertEqual(camera.brightness, 0)
+                self.assertEqual(camera.mirror_state, 0)
+                self.assertEqual(camera.flip_state, 0)
+                self.assertEqual(camera.powersave_mode, 2)
                 self.assertTrue(camera.is_camera_connected)
-                self.assertEqual(camera.get_motion_detection_sensitivity, 80)
+                self.assertEqual(camera.motion_detection_sensitivity, 80)
 
                 image_url = camera._attrs.get("presignedLastImageUrl")
 


### PR DESCRIPTION
**BREAKING CHANGE**
  This patch enhances how the Arlo camera properties are cached and updated.
  Once an attribute is requested, it will be cached and shared for all cameras avoiding a new query. If an update is required, then by calling the camera.update()
  all the attributes will be reloaded too.

@jwillaz  I did a slight modification on your latest patch so now we are saving and sharing the properties across all cameras and now it mandatory to issue an  `update()` to refresh the attributes. 

This PR also introduces some breaking changes since some properties were converted to methods to be more coherent and vice-versa. This way we can keep a better and linear standard between the calls.

Could you guys test this to see if works for you and how the performance goes? 

Thanks!


**Quick test scenario**
```python
USERNAME = 'foo'
PASSWORD = 'secret'

import time
from pyarlo import PyArlo
arlo = PyArlo(USERNAME, PASSWORD)
arlo0, arlo1, arlo2, arlo3 = arlo.cameras

start = time.time() 
arlo3.battery_level
end = time.time()
print(end - start)
4.127991199493408

start = time.time()
arlo2.battery_level
end = time.time()
print(end - start)
0.0002913475036621094

# update data
start = time.time()
arlo1.update()
end = time.time()
print(end - start)
3.838539123535156e-05

## 2nd time

start = time.time() 
arlo3.battery_level
end = time.time()
print(end - start)
0.00035762786865234375

start = time.time()
arlo2.battery_level
end = time.time()
print(end - start)
0.0002608299255371094
```