### PR TITLE
Returning camera base_station as property for cameras ArloCamera

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,22 +72,22 @@ Usage
     cam.unseen_videos
 
     # get brightness value of camera
-    cam.get_brightness
+    cam.brightness
 
     # get signal strength of camera with base station
-    cam.get_signal_strength
+    cam.signal_strength
     
     # get flip property from camera
-    cam.get_flip_state
+    cam.flip_state
 
     # get mirror property from camera
-    cam.get_mirror_state
+    cam.mirror_state
 
     # get power save mode value from camera
-    cam.get_powersave_mode
+    cam.powersave_mode
 
     # get current battery level of camera
-    cam.get_battery_level
+    cam.battery_level
     92
 
     # get boolean result if motion detection
@@ -96,10 +96,10 @@ Usage
 
     # get battery levels of all cameras
     # prints serial number and battery level of each camera
-    base.get_camera_battery_level  # {'4N71235T12345': 92, '4N71235T12345': 90}
+    base.get_cameras_battery_level  # {'4N71235T12345': 92, '4N71235T12345': 90}
 
     # get base station properties
-    base.get_basestation_properties
+    base.properties
 
     # get camera properties
     base.get_camera_properties

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -50,7 +50,9 @@ class TestArloCamera(unittest.TestCase):
         basestation.update()
         self.assertEqual(len(cameras), 2)
         for camera in cameras:
+
             camera.update()
+
             self.assertTrue(camera.__repr__().startswith("<ArloCamera:"))
             self.assertIsNone(arlo.refresh_attributes(camera))
             self.assertIsInstance(camera, ArloCamera)
@@ -61,11 +63,13 @@ class TestArloCamera(unittest.TestCase):
             self.assertEqual(camera.user_role, "ADMIN")
             self.assertTrue(len(camera.captured_today), 1)
             self.assertIsNotNone(camera.properties)
+            self.assertEqual(camera.base_station, basestation)
 
             if camera.name == "Front Door":
                 self.assertTrue(camera.device_id, "48B14CAAAAAAA")
                 self.assertEqual(camera.unique_id, "235-48B14CAAAAAAA")
                 self.assertEqual(camera.unseen_videos, 39)
+                self.assertEqual(camera.parent_id, "48B14CBBBBBBB")
                 self.assertEqual(camera.xcloud_id, "1005-123-999999")
                 self.assertEqual(camera.serial_number, camera.device_id)
 


### PR DESCRIPTION
Added property to return base_station for the given camera. 

```python
from pyarlo import PyArlo
arlo = PyArlo('foor', 'bar')
arlo0, arlo1, arlo2, arlo3 = arlo.cameras
arlo3.base_station
<ArloBaseStation: Home>
arlo3.base_station.update()
```
Dependency required to get the PR https://github.com/home-assistant/home-assistant/pull/9892 approved on HASS.

@jwillaz  I'm going to release a newer `pyarlo` version tonight so then you can update your HASS PR. 