### PR TITLE
Function should must return value (inconsistent-return-statements)

### DIFF
--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -198,6 +198,7 @@ class PyArlo(object):
             lambda cam: cam.device_id == device_id, self.cameras))[0]
         if camera:
             return camera
+        return None
 
     def refresh_attributes(self, name):
         """Refresh attributes from a given Arlo object."""
@@ -206,6 +207,7 @@ class PyArlo(object):
         for device in data:
             if device.get('deviceName') == name:
                 return device
+        return None
 
     @property
     def unseen_videos_reset(self):


### PR DESCRIPTION
Fix function to return value

```
************* Module pyarlo
R:195, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
R:202, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
```