### PR TITLE
Don't update base station when it's not available

### DIFF
--- a/pyarlo/camera.py
+++ b/pyarlo/camera.py
@@ -328,6 +328,7 @@ class ArloCamera(object):
         self._attrs = self._session.refresh_attributes(self.name)
 
         # force base_state to update properties
-        self.base_station.update()
+        if self.base_station:
+            self.base_station.update()
 
 # vim:sw=4:ts=4:et:


### PR DESCRIPTION
There are cameras like Arlo Q, where there's no base station.
This simple fix allows to update the camera without crash on attempt to update base station.