### PR TITLE
Fixes AttributerError when requests failed to get a response

### DIFF
--- a/pyarlo/__init__.py
+++ b/pyarlo/__init__.py
@@ -203,8 +203,12 @@ class PyArlo(object):
     def refresh_attributes(self, name):
         """Refresh attributes from a given Arlo object."""
         url = DEVICES_ENDPOINT
-        data = self.query(url).get('data')
-        for device in data:
+        response = self.query(url)
+
+        if not response or not isinstance(response, dict):
+            return None
+
+        for device in response.get('data'):
             if device.get('deviceName') == name:
                 return device
         return None
@@ -244,9 +248,12 @@ class PyArlo(object):
         # update attributes in all cameras to avoid duped queries
         if update_cameras:
             url = DEVICES_ENDPOINT
-            data = self.query(url).get('data')
+            response = self.query(url)
+            if not response or not isinstance(response, dict):
+                return
+
             for camera in self.cameras:
-                for dev_info in data:
+                for dev_info in response.get('data'):
                     if dev_info.get('deviceName') == camera.name:
                         _LOGGER.debug("Refreshing %s attributes", camera.name)
                         camera.attrs = dev_info


### PR DESCRIPTION
Fixes AttributerError when requests failed to get a response

```python
2018-06-04 23:26:42 ERROR (MainThread) [homeassistant.core] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
result = self.fn(*self.args, **self.kwargs)
File "/home/homeassistant/.homeassistant/custom_components/arlo.py", line 83, in hub_refresh
update_base_station=True)
File "/srv/homeassistant/lib/python3.6/site-packages/pyarlo/init.py", line 262, in update
base.update()
File "/srv/homeassistant/lib/python3.6/site-packages/pyarlo/base_station.py", line 457, in update
self._attrs = self._session.refresh_attributes(self.name)
File "/srv/homeassistant/lib/python3.6/site-packages/pyarlo/init.py", line 206, in refresh_attributes
data = self.query(url).get('data')
AttributeError: 'NoneType' object has no attribute 'get'
```

Fixes: https://github.com/home-assistant/home-assistant/issues/13176#issuecomment-394544654