### PR TITLE
Fix issue where ambient sensor data is never updated

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -684,6 +684,7 @@ class ArloBaseStation(object):
 
         if current_time >= (last_refresh + self._refresh_rate):
             self.get_cameras_properties()
+            self.get_ambient_sensor_data()
             self._attrs = self._session.refresh_attributes(self.name)
             self._attrs = assert_is_dict(self._attrs)
             _LOGGER.debug("Called base station update of camera properties: "

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -83,6 +83,7 @@ class TestArloBaseStation(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_props)
+    @patch.object(ArloBaseStation, "get_ambient_sensor_data", MagicMock())
     def test_camera_properties(self, mock):
         """Test ArloBaseStation.get_cameras_properties."""
         base = self.load_base_station(mock)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -11,7 +11,7 @@ from tests.common import (
     open_fixture
 )
 
-from mock import patch
+from mock import patch, MagicMock
 from pyarlo import PyArlo, ArloBaseStation
 from pyarlo.camera import ArloCamera
 from pyarlo.const import (
@@ -43,6 +43,7 @@ class TestArloCamera(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_camera_props)
+    @patch.object(ArloBaseStation, "get_ambient_sensor_data", MagicMock())
     def test_camera_properties(self, mock):
         """Test ArloCamera properties."""
         arlo = self.load_arlo(mock)

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,7 +1,7 @@
 """The tests for the PyArlo platform."""
 import unittest
 from functools import partial
-from mock import patch
+from mock import patch, MagicMock
 from pyarlo import ArloBaseStation, PyArlo
 from tests.common import load_fixture, load_camera_schedule
 
@@ -84,6 +84,7 @@ class TestArloBaseStationModes(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event", load_modes)
+    @patch.object(ArloBaseStation, "get_ambient_sensor_data", MagicMock())
     def test_set_mode(self, mock):
         """Test PyArlo BaseStation.mode property."""
         notify_url = NOTIFY_ENDPOINT.format("48b14cbbbbbbb")
@@ -108,6 +109,7 @@ class TestArloBaseStationModes(unittest.TestCase):
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish_and_get_event",
                   partial(load_camera_schedule, active=True))
+    @patch.object(ArloBaseStation, "get_ambient_sensor_data", MagicMock)
     def test_set_schedule_mode(self, mock):
         """Test PyArlo BaseStation.mode property."""
         notify_url = NOTIFY_ENDPOINT.format("48b14cbbbbbbb")


### PR DESCRIPTION
Oversight on my part originally - the `get_ambient_sensor_data()` method was never called when the `ArloBaseStation.update()` method is called.