### PR TITLE
Fix errors for cameras without ambient sensors

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -134,7 +134,7 @@ class ArloBaseStation(object):
             while not this_event and i < 2:
                 self.__event_handle.wait(5.0)
                 self.__event_handle.clear()
-                _LOGGER.debug("Instance " + str(i) + " resource: " + resource)
+                _LOGGER.debug("Instance %s resource: %s", str(i), resource)
                 for event in self.__events:
                     if event['resource'] == resource:
                         this_event = event
@@ -390,7 +390,6 @@ class ArloBaseStation(object):
         if resource_event:
             self._last_refresh = int(time.time())
             self._camera_properties = resource_event.get('properties')
-        return
 
     def get_cameras_battery_level(self):
         """Return a list of battery levels of all cameras."""

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -493,6 +493,7 @@ class ArloBaseStation(object):
         """Decode, decompress, and parse the data from the history API"""
         b64_input = ""
         for s in properties.get('payload'):
+            # pylint: disable=consider-using-join
             b64_input += s
 
         decoded = base64.b64decode(b64_input)
@@ -524,7 +525,8 @@ class ArloBaseStation(object):
 
         if i == 32768:
             return None
-        elif scale == 0:
+
+        if scale == 0:
             return i
 
         return float(i) / (scale * 10)
@@ -697,6 +699,5 @@ class ArloBaseStation(object):
             _LOGGER.debug("Called base station update of camera properties: "
                           "Scan Interval: %s, New Properties: %s",
                           self._refresh_rate, self.camera_properties)
-        return
 
 # vim:sw=4:ts=4:et:

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -478,6 +478,10 @@ class ArloBaseStation(object):
         """Refresh ambient sensor history"""
         resource = 'cameras/{}/ambientSensors/history'.format(self.device_id)
         history_event = self.publish_and_get_event(resource)
+
+        if history_event is None:
+            return None
+
         properties = history_event.get('properties')
 
         self._ambient_sensor_data = \
@@ -530,6 +534,10 @@ class ArloBaseStation(object):
         """Gets the most recent ambient sensor history entry"""
         if self._ambient_sensor_data is None:
             self.get_ambient_sensor_data()
+
+        if self._ambient_sensor_data is None:
+            return None
+
         return self._ambient_sensor_data[-1].get(statistic)
 
     def get_audio_playback_status(self):

--- a/pyarlo/utils.py
+++ b/pyarlo/utils.py
@@ -25,9 +25,9 @@ def http_get(url, filename=None):
 
     if filename is None:
         return ret.content
-    else:
-        with open(filename, 'wb') as data:
-            data.write(ret.content)
+
+    with open(filename, 'wb') as data:
+        data.write(ret.content)
     return True
 
 

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -161,6 +161,15 @@ class TestArloBaseStation(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch.object(
+        ArloBaseStation, "publish_and_get_event", lambda x, y: None)
+    def test_latest_sensor_statistic_none(self, mock):
+        """Test ArloBaseStation.get_latest_ambient_sensor_statistic None."""
+        base = self.load_base_station(mock)
+        temperature = base.get_latest_ambient_sensor_statistic("temperature")
+        self.assertEqual(temperature, None)
+
+    @requests_mock.Mocker()
+    @patch.object(
         ArloBaseStation, "publish_and_get_event", load_audio_playback_status)
     def test_audio_playback_status(self, mock):
         """Test ArloBaseStation.get_audio_playback_status."""

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -143,6 +143,14 @@ class TestArloBaseStation(unittest.TestCase):
         self.assertEqual(base.ambient_air_quality, 11.2)
 
     @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", lambda x, y: None)
+    def test_ambient_sensor_data_none(self, mock):
+        """Test ArloBaseStation.get_ambient_sensor_data HTTP error."""
+        base = self.load_base_station(mock)
+        result = base.get_ambient_sensor_data()
+        self.assertEqual(result, None)
+
+    @requests_mock.Mocker()
     @patch.object(
         ArloBaseStation, "publish_and_get_event", load_ambient_sensor_data)
     def test_latest_sensor_statistic(self, mock):


### PR DESCRIPTION
Fix a reference error when `None` is returned from the API when querying ambient sensor data. See https://github.com/home-assistant/home-assistant/issues/15486