### PR TITLE
Adds methods to get speaker volume, night light status and brightness

### DIFF
--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -441,7 +441,7 @@ class ArloBaseStation(object):
             return None
 
         speaker = self.camera_extended_properties.get('speaker')
-        if speaker is None:
+        if not speaker:
             return None
 
         return speaker.get('mute')
@@ -452,7 +452,7 @@ class ArloBaseStation(object):
             return None
 
         speaker = self.camera_extended_properties.get('speaker')
-        if speaker is None:
+        if not speaker:
             return None
 
         return speaker.get('volume')
@@ -463,7 +463,7 @@ class ArloBaseStation(object):
             return None
 
         night_light = self.camera_extended_properties.get('nightLight')
-        if night_light is None:
+        if not night_light:
             return None
 
         if night_light.get('enabled'):
@@ -477,7 +477,7 @@ class ArloBaseStation(object):
             return None
 
         night_light = self.camera_extended_properties.get('nightLight')
-        if night_light is None:
+        if not night_light:
             return None
 
         return night_light.get('brightness')

--- a/pyarlo/base_station.py
+++ b/pyarlo/base_station.py
@@ -443,8 +443,8 @@ class ArloBaseStation(object):
         speaker = self.camera_extended_properties.get('speaker')
         if speaker is None:
             return None
-        else:
-            return speaker.get('mute')
+
+        return speaker.get('mute')
 
     def get_speaker_volume(self):
         """Return the volume setting of the speaker."""
@@ -454,8 +454,8 @@ class ArloBaseStation(object):
         speaker = self.camera_extended_properties.get('speaker')
         if speaker is None:
             return None
-        else:
-            return speaker.get('volume')
+
+        return speaker.get('volume')
 
     def get_night_light_state(self):
         """Return the state of the night light (on/off)."""
@@ -465,10 +465,11 @@ class ArloBaseStation(object):
         night_light = self.camera_extended_properties.get('nightLight')
         if night_light is None:
             return None
-        elif night_light.get('enabled'):
+
+        if night_light.get('enabled'):
             return 'on'
-        else:
-            return 'off'
+
+        return 'off'
 
     def get_night_light_brightness(self):
         """Return the brightness (0-255) of the night light."""
@@ -478,8 +479,8 @@ class ArloBaseStation(object):
         night_light = self.camera_extended_properties.get('nightLight')
         if night_light is None:
             return None
-        else:
-            return night_light.get('brightness')
+
+        return night_light.get('brightness')
 
     @property
     def properties(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -65,6 +65,7 @@ def load_audio_playback_status(*args, **kwargs):
     """Load audio playback status."""
     return load_fixture_json("pyarlo_audio_playback.json")
 
+
 def load_extended_properties(*args, **kwargs):
     """Load extended camera properties."""
     return load_fixture_json("pyarlo_extended_properties.json")

--- a/tests/common.py
+++ b/tests/common.py
@@ -64,3 +64,7 @@ def load_ambient_sensor_data(*args, **kwargs):
 def load_audio_playback_status(*args, **kwargs):
     """Load audio playback status."""
     return load_fixture_json("pyarlo_audio_playback.json")
+
+def load_extended_properties(*args, **kwargs):
+    """Load extended camera properties."""
+    return load_fixture_json("pyarlo_extended_properties.json")

--- a/tests/fixtures/pyarlo_extended_properties.json
+++ b/tests/fixtures/pyarlo_extended_properties.json
@@ -1,0 +1,232 @@
+{
+  "action": "is",
+  "from": "4R03757BA387F",
+  "resource": "cameras",
+  "to": "FQ8QKG-336-14182007_web",
+  "transId": "web!e6d1b969.8aa4b!1498165992111",
+  "properties": {
+    "activityState": "userStreamActive",
+    "audioAnalytics": {
+      "babyCryDetection": {
+        "enabled": true,
+        "triggered": false
+      }
+    },
+    "audioDetected": false,
+    "audioDetection": {
+      "armed": true,
+      "sensitivity": 3
+    },
+    "batteryLevel": 100,
+    "batteryTech": "Rechargeable",
+    "brightness": 2,
+    "capabilities": [
+      "H.264Streaming",
+      "JPEGSnapshot",
+      "SignalStrength",
+      "Privacy",
+      "Standby",
+      {
+        "MaxZoom": 7
+      },
+      {
+        "Resolutions": [
+          {
+            "text": "1080p",
+            "x": 1920,
+            "y": 1080
+          },
+          {
+            "text": "720p",
+            "x": 1280,
+            "y": 720
+          },
+          {
+            "text": "480p",
+            "x": 848,
+            "y": 480
+          },
+          {
+            "text": "360p",
+            "x": 640,
+            "y": 360
+          },
+          {
+            "text": "240p",
+            "x": 416,
+            "y": 240
+          }
+        ]
+      },
+      {
+        "TimedStreamDuration": {
+          "default": 10,
+          "max": 120,
+          "min": 5
+        }
+      },
+      {
+        "TriggerEndStreamDuration": {
+          "default": 300,
+          "max": 300,
+          "min": 10
+        }
+      },
+      {
+        "Triggers": [
+          {
+            "sensitivity": {
+              "default": 5,
+              "max": 9,
+              "min": 1,
+              "step": 1,
+              "type": "integer"
+            },
+            "type": "ivMotionActive"
+          },
+          {
+            "sensitivity": {
+              "default": 3,
+              "max": 5,
+              "min": 1,
+              "step": 1,
+              "type": "integer"
+            },
+            "type": "audioAmplitude"
+          }
+        ]
+      },
+      {
+        "Actions": [
+          {
+            "recordVideo": [
+              {
+                "StopActions": [
+                  "timeout",
+                  "triggerEndDetected"
+                ]
+              }
+            ]
+          },
+          "recordSnapshot",
+          "sendEmailAlert",
+          "pushNotification"
+        ]
+      },
+      {
+        "ambientSensors": [
+          {
+            "desc": "tenths of degrees celcius",
+            "name": "temperature",
+            "type": "long"
+          },
+          {
+            "desc": "tenths of percent rel. humidity",
+            "name": "humidity",
+            "type": "long"
+          },
+          {
+            "desc": "hundredths of quality",
+            "name": "airQuality",
+            "type": "long"
+          }
+        ]
+      }
+    ],
+    "chargerTech": "Regular",
+    "chargingState": "Off",
+    "connectionState": "available",
+    "continuousStreamState": "inactive",
+    "eventAction": {
+      "actionType": "recordVideo",
+      "emailNotification": {
+        "emailList": [
+          "__OWNER_EMAIL__"
+        ],
+        "enabled": false
+      },
+      "pushNotification": false,
+      "stopType": "motionStop",
+      "timeout": 15
+    },
+    "flip": false,
+    "fov": 100,
+    "hasStreamed": true,
+    "hwVersion": "6",
+    "idleLedEnable": false,
+    "lowBatteryLedEnable": true,
+    "mic": {
+      "mute": false,
+      "volume": 100
+    },
+    "mirror": false,
+    "modelId": "ABC1000",
+    "motion": {
+      "zones": [
+        {
+          "color": 45136,
+          "coords": [
+            {
+              "x": 0.164855,
+              "y": 0.091787
+            },
+            {
+              "x": 0.797101,
+              "y": 0.091787
+            },
+            {
+              "x": 0.797101,
+              "y": 0.995169
+            },
+            {
+              "x": 0.164855,
+              "y": 0.995169
+            }
+          ],
+          "id": "769355de-243f-4188-af54-245532f13b9e",
+          "name": "Zone"
+        }
+      ]
+    },
+    "motionDetected": false,
+    "motionDetection": {
+      "armed": true,
+      "sensitivity": 5,
+      "zones": []
+    },
+    "motionSetupModeEnabled": false,
+    "motionSetupModeSensitivity": 80,
+    "name": "",
+    "nightLight": {
+      "brightness": 200,
+      "enabled": false,
+      "mode": "temperature",
+      "sleepTime": 0,
+      "sleepTimeRel": 0,
+      "temperature": 2650
+    },
+    "nightVisionMode": 1,
+    "olsonTimeZone": "America/Chicago",
+    "powerSaveMode": 2,
+    "privacyActive": false,
+    "resolution": {
+      "height": 1080,
+      "width": 1920
+    },
+    "serialNumber": "48B14CAAAAAAA",
+    "signalStrength": 4,
+    "speaker": {
+      "mute": false,
+      "volume": 100
+    },
+    "standbyActive": false,
+    "streamingMode": "eventBased",
+    "swVersion": "1.8.4.5_20140",
+    "zoom": {
+      "bottomrightx": 1280,
+      "bottomrighty": 720,
+      "topleftx": 0,
+      "toplefty": 0
+    }
+  }
+}

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -9,7 +9,8 @@ from tests.common import (
     load_camera_rules,
     load_camera_schedule,
     load_ambient_sensor_data,
-    load_audio_playback_status
+    load_audio_playback_status,
+    load_extended_properties
 )
 
 import requests_mock
@@ -321,6 +322,42 @@ class TestArloBaseStation(unittest.TestCase):
             publish_response=False,
             properties={'nightLight': {'brightness': 100}}
         )
+
+    @requests_mock.Mocker()
+    @patch.object(
+        ArloBaseStation, "publish_and_get_event", load_extended_properties)
+    def test_get_speaker_muted(self, mock):
+        """Test ArloBaseStation.get_speaker_muted."""
+        base = self.load_base_station(mock)
+        result = base.get_speaker_muted()
+        self.assertEqual(result, False)
+
+    @requests_mock.Mocker()
+    @patch.object(
+        ArloBaseStation, "publish_and_get_event", load_extended_properties)
+    def test_get_speaker_volume(self, mock):
+        """Test ArloBaseStation.get_speaker_volume."""
+        base = self.load_base_station(mock)
+        result = base.get_speaker_volume()
+        self.assertEqual(result, 100)
+
+    @requests_mock.Mocker()
+    @patch.object(
+        ArloBaseStation, "publish_and_get_event", load_extended_properties)
+    def test_get_night_light_state(self, mock):
+        """Test ArloBaseStation.get_speaker_volume."""
+        base = self.load_base_station(mock)
+        result = base.get_night_light_state()
+        self.assertEqual(result, 'off')
+
+    @requests_mock.Mocker()
+    @patch.object(
+        ArloBaseStation, "publish_and_get_event", load_extended_properties)
+    def test_get_night_light_brightness(self, mock):
+        """Test ArloBaseStation.get_night_light_brightness."""
+        base = self.load_base_station(mock)
+        result = base.get_night_light_brightness()
+        self.assertEqual(result, 200)
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish", MagicMock())

--- a/tests/test_base_station.py
+++ b/tests/test_base_station.py
@@ -344,11 +344,26 @@ class TestArloBaseStation(unittest.TestCase):
     @requests_mock.Mocker()
     @patch.object(
         ArloBaseStation, "publish_and_get_event", load_extended_properties)
-    def test_get_night_light_state(self, mock):
+    def test_get_night_light_state_off(self, mock):
         """Test ArloBaseStation.get_speaker_volume."""
         base = self.load_base_station(mock)
         result = base.get_night_light_state()
         self.assertEqual(result, 'off')
+
+    @requests_mock.Mocker()
+    @patch.object(
+        ArloBaseStation, "publish_and_get_event", lambda x, y: {
+            'properties': {
+                'nightLight': {
+                    'enabled': True
+                }
+            }
+        })
+    def test_get_night_light_state_on(self, mock):
+        """Test ArloBaseStation.get_speaker_volume."""
+        base = self.load_base_station(mock)
+        result = base.get_night_light_state()
+        self.assertEqual(result, 'on')
 
     @requests_mock.Mocker()
     @patch.object(
@@ -358,6 +373,31 @@ class TestArloBaseStation(unittest.TestCase):
         base = self.load_base_station(mock)
         result = base.get_night_light_brightness()
         self.assertEqual(result, 200)
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", lambda x, y: None)
+    def test_extended_properties_none(self, mock):
+        """Test extended properties when API returns None."""
+        base = self.load_base_station(mock)
+        self.assertEqual(base.get_speaker_muted(), None)
+        self.assertEqual(base.get_speaker_volume(), None)
+        self.assertEqual(base.get_night_light_state(), None)
+        self.assertEqual(base.get_night_light_brightness(), None)
+
+    @requests_mock.Mocker()
+    @patch.object(ArloBaseStation, "publish_and_get_event", lambda x, y: {
+        'properties': {
+            'speaker': None,
+            'nightLight': None
+        }
+    })
+    def test_extended_properties_empty(self, mock):
+        """Test extended properties when API is missing dictionary keys."""
+        base = self.load_base_station(mock)
+        self.assertEqual(base.get_speaker_muted(), None)
+        self.assertEqual(base.get_speaker_volume(), None)
+        self.assertEqual(base.get_night_light_state(), None)
+        self.assertEqual(base.get_night_light_brightness(), None)
 
     @requests_mock.Mocker()
     @patch.object(ArloBaseStation, "publish", MagicMock())


### PR DESCRIPTION
Per #93, adds methods to get extended properties of Arlo Baby camera base stations:

- `base_station.get_speaker_muted()` returns `True` if the speaker is muted, otherwise `False`
- `base_station.get_speaker_volume()` returns the current volume for the speaker (0-100)
- `base_station.get_night_light_state()` returns `"on"` or `"off"` based on the state of the night light
- `base_station.get_night_light_brightness()` returns the brightness of the night light (0-255)

Fixes: #93 