### PR TITLE
ArloMedia does not work when a doorbell device is linked in the account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
     - python: "3.4.2"
       env: TOXENV=lint
 install: pip install -U tox coveralls

--- a/pyarlo/media.py
+++ b/pyarlo/media.py
@@ -62,11 +62,14 @@ class ArloMediaLibrary(object):
 
         for video in data:
             # pylint: disable=cell-var-from-loop
-            srccam = \
-                list(filter(
-                    lambda cam: cam.device_id == video.get('deviceId'),
-                    all_cameras)
-                    )[0]
+            try:
+                srccam = \
+                    list(filter(
+                        lambda cam: cam.device_id == video.get('deviceId'),
+                        all_cameras)
+                        )[0]
+            except IndexError:
+                continue
 
             # make sure only_cameras is a list
             if only_cameras and \


### PR DESCRIPTION
Currently, we don't support Arlo DoorBells and this code is a temporary workaround to get the media library loaded when a doorbell is present.

Fixes: #103