### PR TITLE
Make the type of motion accessible. 

### DIFF
--- a/pyarlo/media.py
+++ b/pyarlo/media.py
@@ -187,6 +187,13 @@ class ArloVideo(object):
             return self._attrs.get('presignedContentUrl')
         return None
 
+    @property
+    def motion_type(self):
+        """Returns the type of motion that triggered the camera. Requires subscription."""
+        if self._attrs is not None:
+            return self._attrs.get("objCategory")
+        return None
+
     def download_thumbnail(self, filename=None):
         """Download JPEG thumbnail.
 


### PR DESCRIPTION
Add a little code to make motion type (named 'objCategory' for some reason) available.  If you have an Arlo Smart subscription, this will return 'None', 'Vehicle', 'Person', 'Animal', depending on how Arlo has categorized the motion.

Tested with Arlo Q (Two with subscription, One without), and Arlo Pro (without subscription)